### PR TITLE
test: add tests for start time and turn flow and end time

### DIFF
--- a/lib/game.rb
+++ b/lib/game.rb
@@ -3,40 +3,49 @@ require './lib/player'
 require './lib/turn'
 
 class Game
-  attr_reader :hidden_code,
-              :player1,
-              :start_time,
-              # :end_time,
-              # :total_time
+  attr_reader :hidden_code
+  attr_accessor :player1
+
 
   def initialize
     @hidden_code = CodeGenerator.new.hidden_code
     @player1     = Player.new
     @time_string = ""
+
   end
 
+  def start_time
+    @start_time = Time.now
+  end
+
+  def turn_flow
+    until @player1.quit == true || @player1.won == true
+      turn = Turn.new(@hidden_code, @player1)
+    end
+  end
+
+  def end_time
+    @end_time = Time.now
+  end
 
   def game_flow
-    @start_time = Time.now
-    sleep(1)
-    # until @player1.quit == true || @player1.won == true
-    #   turn = Turn.new(@hidden_code, @player1)
-    # end
 
-    end_time = Time.now
+    start_time
+    turn_flow
+    end_time
 
     total_time = end_time - start_time
 
-    @time_string = Time.at(total_time).strftime("%M minutes, %S seconds")
+    time_string = Time.at(total_time).strftime("%M minutes, %S seconds")
+
     #this takes the first 0 off of 00 in minutes:
-    @time_string[0] = ""
+    time_string[0] = ""
     if @player1.won == true
-      puts "Congratulations! You guessed the sequence '#{hidden_code.join.to_s.upcase}' in #{player1.number_of_guesses} guesses over #{@time_string}."
+      puts "Congratulations! You guessed the sequence '#{hidden_code.join.to_s.upcase}' in #{player1.number_of_guesses} guesses over #{time_string}."
     end
     replay
   end
 end
-
 
 def replay
     if @player1.won == true

--- a/spec/game_spec.rb
+++ b/spec/game_spec.rb
@@ -10,11 +10,38 @@ describe Game do
   end
 end
 
-describe '#game_flow' do
-  it 'can initiate start time' do
+describe '#start_time' do
+  it 'can initiate a start time' do
     game = Game.new
-    game.game_flow
 
     expect(game.start_time).to be_an_instance_of(Time)
   end
+
+describe '#turn_flow' do
+  it 'can exit game once player wins' do
+    game = Game.new
+    game.player1.win
+#The following test returns nil when the turn flow has successfully exited
+    expect(game.turn_flow).to be(nil)
+  end
+
+  describe '#end_time' do
+    it 'can initiate an end time' do
+      game = Game.new
+
+      expect(game.end_time).to be_an_instance_of(Time)
+    end
+  end
+
+  describe '#game_flow' do
+    it 'can track game time and output message when player wins' do
+      game = Game.new
+      game.player1.win
+
+      expect(game.end_time).to be_an_instance_of(Time)
+      expect(game.end_time).not_to equal(game.start_time)
+      expect(game.player1.win).to be(true)
+    end
+  end
+end
 end


### PR DESCRIPTION
I created tests for start, flow and end.  Still can't resolve the issue with the "time_string" in the game rb code.  It's still pulling in 9 minutes and 59 seconds consistently.  